### PR TITLE
Dropping unused `addedNames` variable in Prototype Proxy

### DIFF
--- a/src/createPrototypeProxy.js
+++ b/src/createPrototypeProxy.js
@@ -116,7 +116,6 @@ export default function createPrototypeProxy() {
     // Find changed property names
     const currentNames = Object.getOwnPropertyNames(current);
     const previousName = Object.getOwnPropertyNames(proxy);
-    const addedNames = difference(currentNames, previousName);
     const removedNames = difference(previousName, currentNames);
 
     // Remove properties and methods that are no longer there


### PR DESCRIPTION
Hello @gaearon. Just started reading the code so I can see whether I can help for #15 and I stumbled upon an unused variable. I therefore propose to drop it unless it serves a future purpose I did not foresee :smile:.