### PR TITLE
Work around JavaScript environments that do not support __proto__

### DIFF
--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -1,6 +1,7 @@
 import createPrototypeProxy from './createPrototypeProxy';
 import bindAutoBindMethods from './bindAutoBindMethods';
 import deleteUnknownAutoBindMethods from './deleteUnknownAutoBindMethods';
+import supportsProtoAssignment from './supportsProtoAssignment';
 
 const RESERVED_STATICS = [
   'length',
@@ -26,7 +27,7 @@ function isEqualDescriptor(a, b) {
   return true;
 }
 
-export default function proxyClass(InitialComponent) {
+function proxyClass(InitialComponent) {
   // Prevent double wrapping.
   // Given a proxy class, return the existing proxy managing it.
   if (Object.prototype.hasOwnProperty.call(InitialComponent, '__reactPatchProxy')) {
@@ -170,4 +171,21 @@ export default function proxyClass(InitialComponent) {
   });
 
   return proxy;
+}
+
+function createFallback(Component) {
+  let CurrentComponent = Component;
+
+  return {
+    get() {
+      return CurrentComponent;
+    },
+    update(NextComponent) {
+      CurrentComponent = NextComponent;
+    }
+  };
+}
+
+export default function createClassProxy(Component) {
+  return supportsProtoAssignment(Component) ? proxyClass(Component) : createFallback(Component);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,11 @@
+import supportsProtoAssignment from './supportsProtoAssignment';
+
+// Display a developer friendly warning if __proto__ is not supported
+if (supportsProtoAssignment({}) === false) {
+  console.warn('This JavaScript environment does not support __proto__. ' +
+               'This means that react-proxy is unable to proxy React Components. ' +
+               'Features that rely on react-proxy, such as react-transform-hmr, ' +
+               'will not function as expected.');
+}
+
 export default from './createClassProxy';

--- a/src/supportsProtoAssignment.js
+++ b/src/supportsProtoAssignment.js
@@ -1,0 +1,3 @@
+export default function supportsProtoAssignment (entity) {
+  return !!entity && (entity.__proto__ instanceof Object)
+};

--- a/test/legacy-support.js
+++ b/test/legacy-support.js
@@ -1,0 +1,30 @@
+import supportsProtoAssignment from '../src/supportsProtoAssignment';
+import createClassProxy from '../src/createClassProxy'
+import expect from 'expect';
+
+describe('legacy support', () => {
+
+  it ('will not create proxy for an entity with no __proto__ value', () => {
+    let noPrototype = Object.create(null);
+
+    expect(supportsProtoAssignment(noPrototype)).toEqual(false);
+  });
+
+  it ('wraps unsupported entities', () => {
+    let noPrototype = Object.create(null);
+    let proxy = createClassProxy(noPrototype);
+
+    expect(proxy.get()).toEqual(noPrototype);
+  });
+
+  it ('updates the reference when a component changes', () => {
+    let noPrototype = Object.create(null);
+    let proxy = createClassProxy(noPrototype);
+    let next = {};
+
+    proxy.update(next);
+
+    expect(proxy.get()).toEqual(next);
+  });
+
+});


### PR DESCRIPTION
Should fix #27.

<img width="1280" alt="screen shot 2015-10-25 at 5 59 50 pm" src="https://cloud.githubusercontent.com/assets/590904/10718156/38946f92-7b42-11e5-820d-1868f34cd6ed.png">

The only final trouble here is that I'm not able to conduct complete end-to-end testing in unison with [`react-transform-hmr`](https://github.com/gaearon/react-transform-hmr) because of required changes in the `react-proxy@2.0.0` release.

But anyway, here it is :)