### PR TITLE
Check whether proxy has method before copying for autoBind map

### DIFF
--- a/src/createPrototypeProxy.js
+++ b/src/createPrototypeProxy.js
@@ -98,7 +98,7 @@ export default function createPrototypeProxy() {
 
     let __reactAutoBindMap = {};
     for (let name in current.__reactAutoBindMap) {
-      if (current.__reactAutoBindMap.hasOwnProperty(name)) {
+      if (typeof proxy[name] === 'function' && current.__reactAutoBindMap.hasOwnProperty(name)) {
         __reactAutoBindMap[name] = proxy[name];
       }
     }


### PR DESCRIPTION
This makes sure that while copying functions from the autoBindMap, that the proxy actually has those functions so we don't end up with "undefined" values which throw an error later on bind.