### PR TITLE
replacing prototype.find on lodash find, since it breaks in IE11 !

### DIFF
--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -32,7 +32,7 @@ function isEqualDescriptor(a, b) {
 // https://github.com/gaearon/react-proxy/issues/50#issuecomment-192928066
 let allProxies = [];
 function findProxy(Component) {
-  const pair = allProxies.find(([key]) => key === Component);
+  const pair = find(allProxies, ([key]) => key === Component);
   return pair ? pair[1] : null;
 }
 function addProxy(Component, proxy) {


### PR DESCRIPTION
closes #52