### PR TITLE
Fix ESLint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,8 +3,9 @@
     "browser": true,
     "node": true
   },
-  "ecmaFeatures": {
-    "modules": true
+  "parserOptions": {
+    sourceType: "module",
+    ecmaVersion: 6
   },
   "parser": "babel-eslint",
   "rules": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",
+    "babel-eslint": "^5.0.0",
     "babel-loader": "^6.2.0",
     "babel-plugin-check-es2015-constants": "^6.3.13",
     "babel-plugin-syntax-jsx": "^6.3.13",
@@ -58,6 +59,7 @@
     "babel-plugin-transform-react-jsx": "^6.4.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "eslint": "^2.4.0",
     "expect": "^1.9.0",
     "mocha": "^2.2.4",
     "react": "^0.13.2",


### PR DESCRIPTION
Wasn't sure if `eslint` and `babel-eslint` were deliberately excluded for some reason, but Atom's linter was having conniptions because they were missing :sweat_smile: Updated `.eslintrc` for v2.0.0 as well.
