### PR TITLE
Rewrite for React Hot Loader 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ deepForceUpdate(rootInstance);
 * Replaces static getters and setters
 * Replaces unbound static methods
 * Replaces static properties unless they were overwritten by code
+* Sets up `this.constructor` to match the most recent class
 
 ## Known Limitations
 
 * Does not replace ES7 instance properties
-* Does not replace bound static methods
 * Replacing a method using [`autobind-decorator`](https://github.com/andreypopp/autobind-decorator) causes its identity to change
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-proxy",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "description": "Proxies React components without unmounting or losing their state.",
   "main": "modules/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-proxy",
-  "version": "2.0.8",
+  "version": "3.0.0-alpha.0",
   "description": "Proxies React components without unmounting or losing their state.",
   "main": "modules/index.js",
   "scripts": {

--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -65,9 +65,7 @@ function proxyClass(InitialComponent) {
     try {
       return component.apply(context, params);
     } catch (err) {
-      // Native ES6 class instantiation
       const instance = new component(...params);
-
       Object.keys(instance).forEach(key => {
         if (RESERVED_STATICS.indexOf(key) > -1) {
           return;

--- a/src/createPrototypeProxy.js
+++ b/src/createPrototypeProxy.js
@@ -34,6 +34,11 @@ export default function createPrototypeProxy() {
     // Copy properties of the original function, if any
     assign(proxiedMethod, current[name]);
     proxiedMethod.toString = proxyToString(name);
+    try {
+      Object.defineProperty(proxiedMethod, 'name', {
+        value: name
+      });
+    } catch (err) { }
 
     return proxiedMethod;
   }

--- a/test/consistency.js
+++ b/test/consistency.js
@@ -205,6 +205,12 @@ describe('consistency', () => {
       expect(propertyNames).toInclude('doNothing');
     });
 
+    it('copies name to new method', () => {
+      let proxy = createProxy(Bar);
+      const Proxy = proxy.get();
+      expect(Proxy.prototype.doNothing.name).toBe('doNothing');
+    });
+
     it('preserves enumerability and writability of methods', () => {
       let proxy = createProxy(Bar);
       const Proxy = proxy.get();

--- a/test/consistency.js
+++ b/test/consistency.js
@@ -40,6 +40,11 @@ function createModernFixtures() {
   }
 
   class Anon extends React.Component {
+    constructor(props) {
+      super(props);
+      throw new Error('Oops.');
+    }
+
     render() {
       return <div>Anon</div>;
     }
@@ -86,6 +91,10 @@ function createClassicFixtures() {
   });
 
   const Anon = React.createClass({
+    getInitialState() {
+      throw new Error('Oops.');
+    },
+
     render() {
       return <div>Anon</div>;
     }
@@ -268,6 +277,12 @@ describe('consistency', () => {
         expect(originalMethod.toString()).toEqual(proxyMethod.toString());
       });
       expect(doNothingBeforeItWasDeleted.toString()).toEqual('<method was deleted>');
+    });
+
+    it('does not swallow constructor errors', () => {
+      let proxy = createProxy(Anon);
+      const Proxy = proxy.get();
+      expect(() => renderer.render(<Proxy />)).toThrow('Oops');
     });
   }
 

--- a/test/inheritance.js
+++ b/test/inheritance.js
@@ -3,41 +3,47 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-class Base1 extends Component {
-  static getY() {
-    return 42;
+function createModernFixtures() {
+  class Base1 extends Component {
+    static getY() {
+      return 42;
+    }
+
+    getX() {
+      return 42;
+    }
+
+    render() {
+      return this.actuallyRender();
+    }
   }
 
-  getX() {
-    return 42;
+  class Base2 extends Component {
+    static getY() {
+      return 43;
+    }
+
+    getX() {
+      return 43;
+    }
+
+    render() {
+      return this.actuallyRender();
+    }
   }
 
-  render() {
-    return this.actuallyRender();
-  }
-}
-
-class Base2 extends Component {
-  static getY() {
-    return 43;
-  }
-
-  getX() {
-    return 43;
-  }
-
-  render() {
-    return this.actuallyRender();
-  }
+  return { Base1, Base2 };
 }
 
 describe('inheritance', () => {
   let renderer;
   let warnSpy;
+  let Base1, Base2;
 
   beforeEach(() => {
     renderer = createShallowRenderer();
     warnSpy = expect.spyOn(console, 'error').andCallThrough();
+    ({ Base1, Base2 } = createModernFixtures());
   });
 
   afterEach(() => {
@@ -45,7 +51,7 @@ describe('inheritance', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  describe('modern only', () => {
+  describe('modern', () => {
     it('replaces a base instance method with proxied base and derived', () => {
       const baseProxy = createProxy(Base1);
       const BaseProxy = baseProxy.get();
@@ -336,18 +342,6 @@ describe('inheritance', () => {
       derivedProxy.update(Derived2);
       instance.forceUpdate();
       expect(renderer.getRenderOutput().props.children).toEqual('4300 nice');
-
-      derivedProxy.update(Derived1);
-      instance.forceUpdate();
-      expect(renderer.getRenderOutput().props.children).toEqual('4300 lol');
-
-      middleProxy.update(Middle1);
-      instance.forceUpdate();
-      expect(renderer.getRenderOutput().props.children).toEqual('430 lol');
-
-      baseProxy.update(Base1);
-      instance.forceUpdate();
-      expect(renderer.getRenderOutput().props.children).toEqual('420 lol');
     });
   });
 });

--- a/test/instance-descriptor.js
+++ b/test/instance-descriptor.js
@@ -3,61 +3,78 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    InstanceDescriptor: class InstanceDescriptor extends Component {
-      get answer() {
-        return this.props.base + 42;
-      }
+function createModernFixtures() {
+  class InstanceDescriptor extends Component {
+    get answer() {
+      return this.props.base + 42;
+    }
 
-      set something(value) {
-        this._something = value * 2;
-      }
+    set something(value) {
+      this._something = value * 2;
+    }
 
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    },
-
-    InstanceDescriptorUpdate: class InstanceDescriptorUpdate extends Component {
-      get answer() {
-        return this.props.base + 43;
-      }
-
-      set something(value) {
-        this._something = value * 3;
-      }
-
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    },
-
-    InstanceDescriptorRemoval: class InstanceDescriptorRemoval extends Component {
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    },
-
-    ThrowingAccessors: class ThrowingAccessors extends Component {
-      get something() {
-        throw new Error();
-      }
-
-      set something(value) {
-        throw new Error();
-      }
+    render() {
+      return <div>{this.answer}</div>;
     }
   }
-};
+
+  class InstanceDescriptorUpdate extends Component {
+    get answer() {
+      return this.props.base + 43;
+    }
+
+    set something(value) {
+      this._something = value * 3;
+    }
+
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  }
+
+  class InstanceDescriptorRemoval extends Component {
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  }
+
+  class ThrowingAccessors extends Component {
+    get something() {
+      throw new Error();
+    }
+
+    set something(value) {
+      throw new Error();
+    }
+  }
+
+  return {
+    InstanceDescriptor,
+    InstanceDescriptorUpdate,
+    InstanceDescriptorRemoval,
+    ThrowingAccessors
+  };
+}
 
 describe('instance descriptor', () => {
   let renderer;
   let warnSpy;
 
+  let InstanceDescriptor;
+  let InstanceDescriptorUpdate;
+  let InstanceDescriptorRemoval;
+  let ThrowingAccessors;
+
   beforeEach(() => {
     renderer = createShallowRenderer();
     warnSpy = expect.spyOn(console, 'error').andCallThrough();
+
+    ({
+      InstanceDescriptor,
+      InstanceDescriptorUpdate,
+      InstanceDescriptorRemoval,
+      ThrowingAccessors
+    } = createModernFixtures());
   });
 
   afterEach(() => {
@@ -65,128 +82,124 @@ describe('instance descriptor', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    const { InstanceDescriptor, InstanceDescriptorUpdate, InstanceDescriptorRemoval, ThrowingAccessors } = fixtures[type];
+  describe('modern', () => {
+    it('does not invoke accessors', () => {
+      const proxy = createProxy(InstanceDescriptor);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(() => proxy.update(ThrowingAccessors)).toNotThrow();
+    });
 
-    describe(type, () => {
-      it('does not invoke accessors', () => {
+    describe('getter', () => {
+      it('is available on proxy class instance', () => {
+        const proxy = createProxy(InstanceDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(142);
+        expect(instance.answer).toEqual(142);
+      });
+
+      it('gets added', () => {
+        const proxy = createProxy(InstanceDescriptorRemoval);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(undefined);
+
+        proxy.update(InstanceDescriptor);
+        renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(142);
+        expect(instance.answer).toEqual(142);
+      });
+
+      it('gets replaced', () => {
+        const proxy = createProxy(InstanceDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(142);
+
+        proxy.update(InstanceDescriptorUpdate);
+        renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(143);
+        expect(instance.answer).toEqual(143);
+
+        proxy.update(InstanceDescriptorRemoval);
+        renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(undefined);
+        expect(instance.answer).toEqual(undefined);
+      });
+
+      it('gets redefined', () => {
+        const proxy = createProxy(InstanceDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(142);
+
+        Object.defineProperty(instance, 'answer', {
+          value: 7
+        });
+
+        proxy.update(InstanceDescriptorUpdate);
+        renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(7);
+        expect(instance.answer).toEqual(7);
+
+        proxy.update(InstanceDescriptorRemoval);
+        renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(7);
+        expect(instance.answer).toEqual(7);
+      });
+    });
+
+    describe('setter', () => {
+      it('is available on proxy class instance', () => {
         const proxy = createProxy(InstanceDescriptor);
         const Proxy = proxy.get();
         const instance = renderer.render(<Proxy />);
-        expect(() => proxy.update(ThrowingAccessors)).toNotThrow();
+        instance.something = 10;
+        expect(instance._something).toEqual(20);
       });
 
-      describe('getter', () => {
-        it('is available on proxy class instance', () => {
-          const proxy = createProxy(InstanceDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(142);
-          expect(instance.answer).toEqual(142);
-        });
+      it('gets added', () => {
+        const proxy = createProxy(InstanceDescriptorRemoval);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy base={100} />);
 
-        it('gets added', () => {
-          const proxy = createProxy(InstanceDescriptorRemoval);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(undefined);
-
-          proxy.update(InstanceDescriptor);
-          renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(142);
-          expect(instance.answer).toEqual(142);
-        });
-
-        it('gets replaced', () => {
-          const proxy = createProxy(InstanceDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(142);
-
-          proxy.update(InstanceDescriptorUpdate);
-          renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(143);
-          expect(instance.answer).toEqual(143);
-
-          proxy.update(InstanceDescriptorRemoval);
-          renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(undefined);
-          expect(instance.answer).toEqual(undefined);
-        });
-
-        it('gets redefined', () => {
-          const proxy = createProxy(InstanceDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(142);
-
-          Object.defineProperty(instance, 'answer', {
-            value: 7
-          });
-
-          proxy.update(InstanceDescriptorUpdate);
-          renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(7);
-          expect(instance.answer).toEqual(7);
-
-          proxy.update(InstanceDescriptorRemoval);
-          renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(7);
-          expect(instance.answer).toEqual(7);
-        });
+        proxy.update(InstanceDescriptor);
+        instance.something = 10;
+        expect(instance._something).toEqual(20);
       });
 
-      describe('setter', () => {
-        it('is available on proxy class instance', () => {
-          const proxy = createProxy(InstanceDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          instance.something = 10;
-          expect(instance._something).toEqual(20);
+      it('gets replaced', () => {
+        const proxy = createProxy(InstanceDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        instance.something = 10;
+        expect(instance._something).toEqual(20);
+
+        proxy.update(InstanceDescriptorUpdate);
+        expect(instance._something).toEqual(20);
+        instance.something = 10;
+        expect(instance._something).toEqual(30);
+
+        proxy.update(InstanceDescriptorRemoval);
+        expect(instance._something).toEqual(30);
+        instance.something = 7;
+        expect(instance.something).toEqual(7);
+        expect(instance._something).toEqual(30);
+      });
+
+      it('gets redefined', () => {
+        const proxy = createProxy(InstanceDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy base={100} />);
+        expect(renderer.getRenderOutput().props.children).toEqual(142);
+
+        Object.defineProperty(instance, 'something', {
+          value: 50
         });
 
-        it('gets added', () => {
-          const proxy = createProxy(InstanceDescriptorRemoval);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy base={100} />);
-
-          proxy.update(InstanceDescriptor);
-          instance.something = 10;
-          expect(instance._something).toEqual(20);
-        });
-
-        it('gets replaced', () => {
-          const proxy = createProxy(InstanceDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          instance.something = 10;
-          expect(instance._something).toEqual(20);
-
-          proxy.update(InstanceDescriptorUpdate);
-          expect(instance._something).toEqual(20);
-          instance.something = 10;
-          expect(instance._something).toEqual(30);
-
-          proxy.update(InstanceDescriptorRemoval);
-          expect(instance._something).toEqual(30);
-          instance.something = 7;
-          expect(instance.something).toEqual(7);
-          expect(instance._something).toEqual(30);
-        });
-
-        it('gets redefined', () => {
-          const proxy = createProxy(InstanceDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy base={100} />);
-          expect(renderer.getRenderOutput().props.children).toEqual(142);
-
-          Object.defineProperty(instance, 'something', {
-            value: 50
-          });
-
-          proxy.update(InstanceDescriptorUpdate);
-          expect(instance.something).toEqual(50);
-        });
+        proxy.update(InstanceDescriptorUpdate);
+        expect(instance.something).toEqual(50);
       });
     });
   });

--- a/test/instance-method-autobinding.js
+++ b/test/instance-method-autobinding.js
@@ -4,134 +4,146 @@ import autobind from './helpers/autobind';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  classic: {
-    Counter1x: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
+function createModernFixtures() {
+  class Counter1x extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
 
-      increment() {
-        this.setState({
-          counter: this.state.counter + 1
-        });
-      },
+    @autobind
+    increment() {
+      this.setState({
+        counter: this.state.counter + 1
+      });
+    }
 
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    }),
-
-    Counter10x: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 10
-        });
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    }),
-
-    Counter100x: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 100
-        });
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    }),
-
-    CounterWithoutIncrementMethod: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    })
-  },
-
-  modern: {
-    Counter1x: class Counter1x extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      @autobind
-      increment() {
-        this.setState({
-          counter: this.state.counter + 1
-        });
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    },
-
-    Counter10x: class Counter10x extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      @autobind
-      increment() {
-        this.setState({
-          counter: this.state.counter + 10
-        });
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    },
-
-    Counter100x: class Counter100x extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      @autobind
-      increment() {
-        this.setState({
-          counter: this.state.counter + 100
-        });
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    },
-
-    CounterWithoutIncrementMethod: class CounterWithoutIncrementMethod extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
+    render() {
+      return <span>{this.state.counter}</span>;
     }
   }
-};
+
+  class Counter10x extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    @autobind
+    increment() {
+      this.setState({
+        counter: this.state.counter + 10
+      });
+    }
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  }
+
+  class Counter100x extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    @autobind
+    increment() {
+      this.setState({
+        counter: this.state.counter + 100
+      });
+    }
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  }
+
+  class CounterWithoutIncrementMethod extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  }
+
+  return {
+    Counter1x,
+    Counter10x,
+    Counter100x,
+    CounterWithoutIncrementMethod
+  };
+}
+
+function createClassicFixtures() {
+  const Counter1x = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 1
+      });
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  const Counter10x = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 10
+      });
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  const Counter100x = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 100
+      });
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  const CounterWithoutIncrementMethod = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  return {
+    Counter1x,
+    Counter10x,
+    Counter100x,
+    CounterWithoutIncrementMethod
+  };
+}
 
 describe('autobound instance method', () => {
   let renderer;
@@ -147,50 +159,61 @@ describe('autobound instance method', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const { Counter1x, Counter10x, Counter100x, CounterWithoutIncrementMethod } = fixtures[type];
+  function runCommonTests(createFixtures) {
+    let Counter1x;
+    let Counter10x;
+    let Counter100x;
+    let CounterWithoutIncrementMethod;
 
-      it('gets autobound', () => {
-        const proxy = createProxy(CounterWithoutIncrementMethod);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-
-        proxy.update(Counter1x);
-        instance.increment.call(null);
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-      });
-
-      it('is autobound after getting replaced', () => {
-        const proxy = createProxy(Counter1x);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-        instance.increment.call(null);
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-
-        proxy.update(Counter10x);
-        instance.increment.call(null);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(11);
-
-        proxy.update(Counter100x);
-        instance.increment.call(null);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(111);
-      });
+    beforeEach(() => {
+      ({
+        Counter1x,
+        Counter10x,
+        Counter100x,
+        CounterWithoutIncrementMethod
+      } = createFixtures());
     });
-  });
 
-  describe('classic only', () => {
-    const { Counter1x, Counter10x, Counter100x } = fixtures.classic;
+    it('gets autobound', () => {
+      const proxy = createProxy(CounterWithoutIncrementMethod);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+
+      proxy.update(Counter1x);
+      instance.increment.call(null);
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+    });
+
+    it('is autobound after getting replaced', () => {
+      const proxy = createProxy(Counter1x);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+      instance.increment.call(null);
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+
+      proxy.update(Counter10x);
+      instance.increment.call(null);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(11);
+
+      proxy.update(Counter100x);
+      instance.increment.call(null);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(111);
+    });
+  }
+
+  describe('classic', () => {
+    runCommonTests(createClassicFixtures);
 
     /**
      * Important in case it's a subscription that
      * later needs to gets destroyed.
      */
     it('preserves the reference', () => {
+      const { Counter1x, Counter10x, Counter100x } = createClassicFixtures();
       const proxy = createProxy(Counter1x);
       const Proxy = proxy.get();
       const instance = renderer.render(<Proxy />);
@@ -202,17 +225,16 @@ describe('autobound instance method', () => {
       proxy.update(Counter100x);
       expect(instance.increment).toBe(savedIncrement);
     });
-  });
+  })
 
-  describe('modern only', () => {
-    const { Counter1x, Counter10x, Counter100x } = fixtures.modern;
-
+  describe('modern', () => {
     /**
      * There's nothing we can do here.
      * You can't use a lazy autobind with hot reloading
      * and expect function reference equality.
      */
     it('does not preserve the reference (known limitation)', () => {
+      const { Counter1x, Counter10x, Counter100x } = createModernFixtures();
       const proxy = createProxy(Counter1x);
       const Proxy = proxy.get();
       const instance = renderer.render(<Proxy />);

--- a/test/instance-method.js
+++ b/test/instance-method.js
@@ -3,134 +3,148 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    shouldWarnOnBind: false,
+function createModernFixtures() {
+  const shouldWarnOnBind = false;
 
-    Counter1x: class Counter1x extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 1
-        });
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    },
-
-    Counter10x: class Counter10x extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 10
-        });
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    },
-
-    Counter100x: class Counter100x extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 100
-        });
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    },
-
-    CounterWithoutIncrementMethod: class CounterWithoutIncrementMethod extends Component {
-      constructor(props) {
-        super(props);
-        this.state = { counter: 0 };
-      }
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
+  class Counter1x extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
     }
-  },
 
-  classic: {
-    shouldWarnOnBind: true,
+    increment() {
+      this.setState({
+        counter: this.state.counter + 1
+      });
+    }
 
-    Counter1x: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 1
-        });
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    }),
-
-    Counter10x: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 10
-        });
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    }),
-
-    Counter100x: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      increment() {
-        this.setState({
-          counter: this.state.counter + 100
-        });
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    }),
-
-    CounterWithoutIncrementMethod: React.createClass({
-      getInitialState() {
-        return { counter: 0 };
-      },
-
-      render() {
-        return <span>{this.state.counter}</span>;
-      }
-    })
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
   }
+
+  class Counter10x extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 10
+      });
+    }
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  }
+
+  class Counter100x extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 100
+      });
+    }
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  }
+
+  class CounterWithoutIncrementMethod extends Component {
+    constructor(props) {
+      super(props);
+      this.state = { counter: 0 };
+    }
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  }
+
+  return {
+    shouldWarnOnBind,
+    Counter1x,
+    Counter10x,
+    Counter100x,
+    CounterWithoutIncrementMethod
+  };
+}
+
+function createClassicFixtures() {
+  const shouldWarnOnBind = true;
+
+  const Counter1x = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 1
+      });
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  const Counter10x = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 10
+      });
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  const Counter100x = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    increment() {
+      this.setState({
+        counter: this.state.counter + 100
+      });
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  const CounterWithoutIncrementMethod = React.createClass({
+    getInitialState() {
+      return { counter: 0 };
+    },
+
+    render() {
+      return <span>{this.state.counter}</span>;
+    }
+  });
+
+  return {
+    shouldWarnOnBind,
+    Counter1x,
+    Counter10x,
+    Counter100x,
+    CounterWithoutIncrementMethod
+  };
 };
 
 describe('instance method', () => {
@@ -147,137 +161,157 @@ describe('instance method', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const { Counter1x, Counter10x, Counter100x, CounterWithoutIncrementMethod, shouldWarnOnBind } = fixtures[type];
+  function runCommonTests(createFixtures) {
+    let shouldWarnOnBind;
+    let Counter1x;
+    let Counter10x;
+    let Counter100x;
+    let CounterWithoutIncrementMethod;
 
-      it('gets added', () => {
-        const proxy = createProxy(CounterWithoutIncrementMethod);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-
-        proxy.update(Counter1x);
-        instance.increment();
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-      });
-
-      it('gets replaced', () => {
-        const proxy = createProxy(Counter1x);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-        instance.increment();
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-
-        proxy.update(Counter10x);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(11);
-
-        proxy.update(Counter100x);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(111);
-      });
-
-      it('gets replaced if bound by assignment', () => {
-        const proxy = createProxy(Counter1x);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-
-        warnSpy.destroy();
-        const localWarnSpy = expect.spyOn(console, 'error');
-
-        instance.increment = instance.increment.bind(instance);
-
-        expect(localWarnSpy.calls.length).toBe(shouldWarnOnBind ? 1 : 0);
-        localWarnSpy.destroy();
-
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-        instance.increment();
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-
-        proxy.update(Counter10x);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(11);
-
-        proxy.update(Counter100x);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(111);
-      });
-
-      it('gets replaced if bound by redefinition', () => {
-        const proxy = createProxy(Counter1x);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-
-        warnSpy.destroy();
-        const localWarnSpy = expect.spyOn(console, 'error');
-
-        Object.defineProperty(instance, 'increment', {
-          value: instance.increment.bind(instance)
-        });
-
-        expect(localWarnSpy.calls.length).toBe(shouldWarnOnBind ? 1 : 0);
-        localWarnSpy.destroy();
-
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-        instance.increment();
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-
-        proxy.update(Counter10x);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(11);
-
-        proxy.update(Counter100x);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(111);
-      });
-
-      /**
-       * It is important to make deleted methods no-ops
-       * so they don't crash if setTimeout-d or setInterval-d.
-       */
-      it('is detached and acts as a no-op if not reassigned and deleted', () => {
-        const proxy = createProxy(Counter1x);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-        instance.increment();
-        const savedIncrement = instance.increment;
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-
-        proxy.update(CounterWithoutIncrementMethod);
-        expect(instance.increment).toEqual(undefined);
-        savedIncrement.call(instance);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-      });
-
-      it('is attached and acts as a no-op if reassigned and deleted', () => {
-        const proxy = createProxy(Counter1x);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-
-        // Pass an additional argument so that in classic mode,
-        // autobinding doesn't provide us a cached bound handler,
-        // and instead actually performs the bind (which is being tested).
-        instance.increment = instance.increment.bind(instance, 'lol');
-
-        expect(renderer.getRenderOutput().props.children).toEqual(0);
-        instance.increment();
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-
-        proxy.update(CounterWithoutIncrementMethod);
-        instance.increment();
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(1);
-      });
+    beforeEach(() => {
+      ({
+        shouldWarnOnBind,
+        Counter1x,
+        Counter10x,
+        Counter100x,
+        CounterWithoutIncrementMethod
+      } = createFixtures());
     });
+
+    it('gets added', () => {
+      const proxy = createProxy(CounterWithoutIncrementMethod);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+
+      proxy.update(Counter1x);
+      instance.increment();
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+    });
+
+    it('gets replaced', () => {
+      const proxy = createProxy(Counter1x);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+      instance.increment();
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+
+      proxy.update(Counter10x);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(11);
+
+      proxy.update(Counter100x);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(111);
+    });
+
+    it('gets replaced if bound by assignment', () => {
+      const proxy = createProxy(Counter1x);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+
+      warnSpy.destroy();
+      const localWarnSpy = expect.spyOn(console, 'error');
+
+      instance.increment = instance.increment.bind(instance);
+
+      expect(localWarnSpy.calls.length).toBe(shouldWarnOnBind ? 1 : 0);
+      localWarnSpy.destroy();
+
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+      instance.increment();
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+
+      proxy.update(Counter10x);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(11);
+
+      proxy.update(Counter100x);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(111);
+    });
+
+    it('gets replaced if bound by redefinition', () => {
+      const proxy = createProxy(Counter1x);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+
+      warnSpy.destroy();
+      const localWarnSpy = expect.spyOn(console, 'error');
+
+      Object.defineProperty(instance, 'increment', {
+        value: instance.increment.bind(instance)
+      });
+
+      expect(localWarnSpy.calls.length).toBe(shouldWarnOnBind ? 1 : 0);
+      localWarnSpy.destroy();
+
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+      instance.increment();
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+
+      proxy.update(Counter10x);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(11);
+
+      proxy.update(Counter100x);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(111);
+    });
+
+    /**
+     * It is important to make deleted methods no-ops
+     * so they don't crash if setTimeout-d or setInterval-d.
+     */
+    it('is detached and acts as a no-op if not reassigned and deleted', () => {
+      const proxy = createProxy(Counter1x);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+      instance.increment();
+      const savedIncrement = instance.increment;
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+
+      proxy.update(CounterWithoutIncrementMethod);
+      expect(instance.increment).toEqual(undefined);
+      savedIncrement.call(instance);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+    });
+
+    it('is attached and acts as a no-op if reassigned and deleted', () => {
+      const proxy = createProxy(Counter1x);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+
+      // Pass an additional argument so that in classic mode,
+      // autobinding doesn't provide us a cached bound handler,
+      // and instead actually performs the bind (which is being tested).
+      instance.increment = instance.increment.bind(instance, 'lol');
+
+      expect(renderer.getRenderOutput().props.children).toEqual(0);
+      instance.increment();
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+
+      proxy.update(CounterWithoutIncrementMethod);
+      instance.increment();
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(1);
+    });
+  }
+
+  describe('classic', () => {
+    runCommonTests(createClassicFixtures);
+  });
+
+  describe('modern', () => {
+    runCommonTests(createModernFixtures);
   });
 });

--- a/test/instance-property.js
+++ b/test/instance-property.js
@@ -3,59 +3,69 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    InstanceProperty: class InstanceProperty extends Component {
-      answer = 42;
+function createModernFixtures() {
+  class InstanceProperty extends Component {
+    answer = 42;
 
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    },
-
-    InstancePropertyUpdate: class InstancePropertyUpdate extends Component {
-      answer = 43;
-
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    },
-
-    InstancePropertyRemoval: class InstancePropertyRemoval extends Component {
-      render() {
-        return <div>{this.answer}</div>;
-      }
+    render() {
+      return <div>{this.answer}</div>;
     }
-  },
-
-  classic: {
-    InstanceProperty: React.createClass({
-      componentWillMount() {
-        this.answer = 42;
-      },
-
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    }),
-
-    InstancePropertyUpdate: React.createClass({
-      componentWillMount() {
-        this.answer = 43;
-      },
-
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    }),
-
-    InstancePropertyRemoval: React.createClass({
-      render() {
-        return <div>{this.answer}</div>;
-      }
-    })
   }
-};
+
+  class InstancePropertyUpdate extends Component {
+    answer = 43;
+
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  }
+
+  class InstancePropertyRemoval extends Component {
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  }
+
+  return {
+    InstanceProperty,
+    InstancePropertyUpdate,
+    InstancePropertyRemoval
+  };
+}
+
+function createClassicFixtures() {
+  const InstanceProperty = React.createClass({
+    componentWillMount() {
+      this.answer = 42;
+    },
+
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  });
+
+  const InstancePropertyUpdate = React.createClass({
+    componentWillMount() {
+      this.answer = 43;
+    },
+
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  });
+
+  const InstancePropertyRemoval = React.createClass({
+    render() {
+      return <div>{this.answer}</div>;
+    }
+  });
+
+  return {
+    InstanceProperty,
+    InstancePropertyUpdate,
+    InstancePropertyRemoval
+  };
+}
 
 describe('instance property', () => {
   let renderer;
@@ -71,59 +81,75 @@ describe('instance property', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const { InstanceProperty, InstancePropertyUpdate, InstancePropertyRemoval } = fixtures[type];
+  function runCommonTests(createFixtures) {
+    let InstanceProperty;
+    let InstancePropertyUpdate;
+    let InstancePropertyRemoval;
 
-      it('is available on proxy class instance', () => {
-        const proxy = createProxy(InstanceProperty);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(instance.answer).toEqual(42);
-      });
-
-      it('is left unchanged when reassigned', () => {
-        const proxy = createProxy(InstanceProperty);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-        instance.answer = 100;
-
-        proxy.update(InstancePropertyUpdate);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(100);
-        expect(instance.answer).toEqual(100);
-
-        proxy.update(InstancePropertyRemoval);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(100);
-        expect(instance.answer).toEqual(100);
-      });
-
-      /**
-       * I'm not aware of any way of retrieving their new values
-       * without calling the constructor, which seems like too much
-       * of a side effect. We also don't want to overwrite them
-       * in case they changed.
-       */
-      it('is left unchanged even if not reassigned (known limitation)', () => {
-        const proxy = createProxy(InstanceProperty);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-        proxy.update(InstancePropertyUpdate);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(instance.answer).toEqual(42);
-
-        proxy.update(InstancePropertyRemoval);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(instance.answer).toEqual(42);
-      });
+    beforeEach(() => {
+      ({
+        InstanceProperty,
+        InstancePropertyUpdate,
+        InstancePropertyRemoval
+      } = createFixtures());
     });
+
+    it('is available on proxy class instance', () => {
+      const proxy = createProxy(InstanceProperty);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(instance.answer).toEqual(42);
+    });
+
+    it('is left unchanged when reassigned', () => {
+      const proxy = createProxy(InstanceProperty);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+
+      instance.answer = 100;
+
+      proxy.update(InstancePropertyUpdate);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(100);
+      expect(instance.answer).toEqual(100);
+
+      proxy.update(InstancePropertyRemoval);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(100);
+      expect(instance.answer).toEqual(100);
+    });
+
+    /**
+     * I'm not aware of any way of retrieving their new values
+     * without calling the constructor, which seems like too much
+     * of a side effect. We also don't want to overwrite them
+     * in case they changed.
+     */
+    it('is left unchanged even if not reassigned (known limitation)', () => {
+      const proxy = createProxy(InstanceProperty);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+
+      proxy.update(InstancePropertyUpdate);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(instance.answer).toEqual(42);
+
+      proxy.update(InstancePropertyRemoval);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(instance.answer).toEqual(42);
+    });
+  }
+
+  describe('classic', () => {
+    runCommonTests(createClassicFixtures);
+  });
+
+  describe('modern', () => {
+    runCommonTests(createModernFixtures);
   });
 });

--- a/test/pure-component.js
+++ b/test/pure-component.js
@@ -3,21 +3,25 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  pure: {
-    Bar(props) {
-      return <div {...props}>Bar</div>;
-    },
-
-    Baz(props) {
-      return <div {...props}>Baz</div>;
-    },
-
-    Foo(props) {
-      return <div {...props}>Foo</div>;
-    }
+function createPureFixtures() {
+  function Bar(props) {
+    return <div {...props}>Bar</div>;
   }
-};
+
+  function Baz(props) {
+    return <div {...props}>Baz</div>;
+  }
+
+  function Foo(props) {
+    return <div {...props}>Foo</div>;
+  }
+
+  return {
+    Bar,
+    Baz,
+    Foo
+  };
+}
 
 describe('pure component', () => {
   let renderer;
@@ -33,24 +37,32 @@ describe('pure component', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const { Bar, Baz, Foo } = fixtures[type];
+  describe('pure', () => {
+    let Bar;
+    let Baz;
+    let Foo;
 
-      it('gets replaced', () => {
-        const proxy = createProxy(Bar);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Bar');
+    beforeEach(() => {
+      ({
+        Bar,
+        Baz,
+        Foo
+      } = createPureFixtures());
+    });
 
-        proxy.update(Baz);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Baz');
+    it('gets replaced', () => {
+      const proxy = createProxy(Bar);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Bar');
 
-        proxy.update(Foo);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Foo');
-      });
+      proxy.update(Baz);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Baz');
+
+      proxy.update(Foo);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Foo');
     });
   });
 });

--- a/test/pure-component.js
+++ b/test/pure-component.js
@@ -16,10 +16,20 @@ function createPureFixtures() {
     return <div {...props}>Foo</div>;
   }
 
+  function Qux() {
+    throw new Error('Oops.');
+  }
+
+  const Quy = () => {
+    throw new Error('Ouch.');
+  }
+
   return {
     Bar,
     Baz,
-    Foo
+    Foo,
+    Qux,
+    Quy
   };
 }
 
@@ -41,12 +51,16 @@ describe('pure component', () => {
     let Bar;
     let Baz;
     let Foo;
+    let Qux;
+    let Quy;
 
     beforeEach(() => {
       ({
         Bar,
         Baz,
-        Foo
+        Foo,
+        Qux,
+        Quy
       } = createPureFixtures());
     });
 
@@ -63,6 +77,15 @@ describe('pure component', () => {
       proxy.update(Foo);
       renderer.render(<Proxy />);
       expect(renderer.getRenderOutput().props.children).toEqual('Foo');
+    });
+
+    it('does not swallow errors', () => {
+      const proxy = createProxy(Qux);
+      const Proxy = proxy.get();
+      expect(() => renderer.render(<Proxy />)).toThrow('Oops.');
+
+      proxy.update(Quy);
+      expect(() => renderer.render(<Proxy />)).toThrow('Ouch.');
     });
   });
 });

--- a/test/static-descriptor.js
+++ b/test/static-descriptor.js
@@ -3,53 +3,58 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    StaticDescriptor: class StaticDescriptor extends Component {
-      static get answer() {
-        return 42;
-      }
+function createModernFixtures() {
+  class StaticDescriptor extends Component {
+    static get answer() {
+      return 42;
+    }
 
-      static set something(value) {
-        this._something = value * 2;
-      }
+    static set something(value) {
+      this._something = value * 2;
+    }
 
-      render() {
-        return <div>{this.constructor.answer}</div>;
-      }
-    },
-
-    StaticDescriptorUpdate: class StaticDescriptorUpdate extends Component {
-      static get answer() {
-        return 43;
-      }
-
-      static set something(value) {
-        this._something = value * 3;
-      }
-
-      render() {
-        return <div>{this.constructor.answer}</div>;
-      }
-    },
-
-    StaticDescriptorRemoval: class StaticDescriptorRemoval extends Component {
-      render() {
-        return <div>{this.constructor.answer}</div>;
-      }
-    },
-
-    ThrowingAccessors: class ThrowingAccessors extends Component {
-      static get something() {
-        throw new Error();
-      }
-
-      static set something(value) {
-        throw new Error();
-      }
+    render() {
+      return <div>{this.constructor.answer}</div>;
     }
   }
-};
+
+  class StaticDescriptorUpdate extends Component {
+    static get answer() {
+      return 43;
+    }
+
+    static set something(value) {
+      this._something = value * 3;
+    }
+
+    render() {
+      return <div>{this.constructor.answer}</div>;
+    }
+  }
+
+  class StaticDescriptorRemoval extends Component {
+    render() {
+      return <div>{this.constructor.answer}</div>;
+    }
+  }
+
+  class ThrowingAccessors extends Component {
+    static get something() {
+      throw new Error();
+    }
+
+    static set something(value) {
+      throw new Error();
+    }
+  }
+
+  return {
+    StaticDescriptor,
+    StaticDescriptorUpdate,
+    StaticDescriptorRemoval,
+    ThrowingAccessors
+  };
+}
 
 describe('static descriptor', () => {
   let renderer;
@@ -65,128 +70,138 @@ describe('static descriptor', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    const { StaticDescriptor, StaticDescriptorUpdate, StaticDescriptorRemoval, ThrowingAccessors } = fixtures[type];
+  describe('modern', () => {
+    let StaticDescriptor;
+    let StaticDescriptorUpdate;
+    let StaticDescriptorRemoval;
+    let ThrowingAccessors;
 
-    describe(type, () => {
-      it('does not invoke accessors', () => {
+    beforeEach(() => {
+      ({
+        StaticDescriptor,
+        StaticDescriptorUpdate,
+        StaticDescriptorRemoval,
+        ThrowingAccessors
+      } = createModernFixtures());
+    });
+
+    it('does not invoke accessors', () => {
+      const proxy = createProxy(StaticDescriptor);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(() => proxy.update(ThrowingAccessors)).toNotThrow();
+    });
+
+    describe('getter', () => {
+      it('is available on proxy class', () => {
         const proxy = createProxy(StaticDescriptor);
         const Proxy = proxy.get();
         const instance = renderer.render(<Proxy />);
-        expect(() => proxy.update(ThrowingAccessors)).toNotThrow();
+        expect(renderer.getRenderOutput().props.children).toEqual(42);
+        expect(instance.constructor.answer).toEqual(42);
+        expect(Proxy.answer).toEqual(42);
       });
 
-      describe('getter', () => {
-        it('is available on proxy class', () => {
-          const proxy = createProxy(StaticDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(42);
-          expect(instance.constructor.answer).toEqual(42);
-          expect(Proxy.answer).toEqual(42);
-        });
+      it('gets added', () => {
+        const proxy = createProxy(StaticDescriptorRemoval);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(undefined);
 
-        it('gets added', () => {
-          const proxy = createProxy(StaticDescriptorRemoval);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(undefined);
-
-          proxy.update(StaticDescriptor);
-          renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(42);
-          expect(instance.constructor.answer).toEqual(42);
-        });
-
-        it('gets replaced', () => {
-          const proxy = createProxy(StaticDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-          proxy.update(StaticDescriptorUpdate);
-          renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(43);
-          expect(instance.constructor.answer).toEqual(43);
-
-          proxy.update(StaticDescriptorRemoval);
-          renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(undefined);
-          expect(instance.answer).toEqual(undefined);
-        });
-
-        it('gets redefined', () => {
-          const proxy = createProxy(StaticDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-          Object.defineProperty(instance.constructor, 'answer', {
-            value: 7
-          });
-
-          proxy.update(StaticDescriptorUpdate);
-          renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(7);
-          expect(instance.constructor.answer).toEqual(7);
-
-          proxy.update(StaticDescriptorRemoval);
-          renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(7);
-          expect(instance.constructor.answer).toEqual(7);
-        });
+        proxy.update(StaticDescriptor);
+        renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(42);
+        expect(instance.constructor.answer).toEqual(42);
       });
 
-      describe('setter', () => {
-        it('is available on proxy class instance', () => {
-          const proxy = createProxy(StaticDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          instance.constructor.something = 10;
+      it('gets replaced', () => {
+        const proxy = createProxy(StaticDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(42);
+
+        proxy.update(StaticDescriptorUpdate);
+        renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(43);
+        expect(instance.constructor.answer).toEqual(43);
+
+        proxy.update(StaticDescriptorRemoval);
+        renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(undefined);
+        expect(instance.answer).toEqual(undefined);
+      });
+
+      it('gets redefined', () => {
+        const proxy = createProxy(StaticDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(42);
+
+        Object.defineProperty(instance.constructor, 'answer', {
+          value: 7
         });
 
-        it('gets added', () => {
-          const proxy = createProxy(StaticDescriptorRemoval);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
+        proxy.update(StaticDescriptorUpdate);
+        renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(7);
+        expect(instance.constructor.answer).toEqual(7);
 
-          proxy.update(StaticDescriptor);
-          instance.constructor.something = 10;
-          expect(instance.constructor._something).toEqual(20);
+        proxy.update(StaticDescriptorRemoval);
+        renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(7);
+        expect(instance.constructor.answer).toEqual(7);
+      });
+    });
+
+    describe('setter', () => {
+      it('is available on proxy class instance', () => {
+        const proxy = createProxy(StaticDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        instance.constructor.something = 10;
+      });
+
+      it('gets added', () => {
+        const proxy = createProxy(StaticDescriptorRemoval);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+
+        proxy.update(StaticDescriptor);
+        instance.constructor.something = 10;
+        expect(instance.constructor._something).toEqual(20);
+      });
+
+      it('gets replaced', () => {
+        const proxy = createProxy(StaticDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        instance.constructor.something = 10;
+        expect(instance.constructor._something).toEqual(20);
+
+        proxy.update(StaticDescriptorUpdate);
+        expect(instance.constructor._something).toEqual(20);
+        instance.constructor.something = 10;
+        expect(instance.constructor._something).toEqual(30);
+
+        proxy.update(StaticDescriptorRemoval);
+        expect(instance.constructor._something).toEqual(30);
+        instance.constructor.something = 7;
+        expect(instance.constructor.something).toEqual(7);
+        expect(instance.constructor._something).toEqual(30);
+      });
+
+      it('gets redefined', () => {
+        const proxy = createProxy(StaticDescriptor);
+        const Proxy = proxy.get();
+        const instance = renderer.render(<Proxy />);
+        expect(renderer.getRenderOutput().props.children).toEqual(42);
+
+        Object.defineProperty(instance.constructor, 'something', {
+          value: 50
         });
 
-        it('gets replaced', () => {
-          const proxy = createProxy(StaticDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          instance.constructor.something = 10;
-          expect(instance.constructor._something).toEqual(20);
-
-          proxy.update(StaticDescriptorUpdate);
-          expect(instance.constructor._something).toEqual(20);
-          instance.constructor.something = 10;
-          expect(instance.constructor._something).toEqual(30);
-
-          proxy.update(StaticDescriptorRemoval);
-          expect(instance.constructor._something).toEqual(30);
-          instance.constructor.something = 7;
-          expect(instance.constructor.something).toEqual(7);
-          expect(instance.constructor._something).toEqual(30);
-        });
-
-        it('gets redefined', () => {
-          const proxy = createProxy(StaticDescriptor);
-          const Proxy = proxy.get();
-          const instance = renderer.render(<Proxy />);
-          expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-          Object.defineProperty(instance.constructor, 'something', {
-            value: 50
-          });
-
-          proxy.update(StaticDescriptorUpdate);
-          expect(instance.constructor.something).toEqual(50);
-        });
+        proxy.update(StaticDescriptorUpdate);
+        expect(instance.constructor.something).toEqual(50);
       });
     });
   });

--- a/test/static-method.js
+++ b/test/static-method.js
@@ -3,79 +3,89 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    StaticMethod: class StaticMethod extends Component {
-      static getAnswer() {
-        return 42;
-      };
+function createModernFixtures() {
+  class StaticMethod extends Component {
+    static getAnswer() {
+      return 42;
+    };
 
-      render() {
-        return (
-          <div>{this.constructor.getAnswer()}</div>
-        );
-      }
-    },
-
-    StaticMethodUpdate: class StaticMethodUpdate extends Component {
-      static getAnswer() {
-        return 43;
-      };
-
-      render() {
-        return (
-          <div>{this.constructor.getAnswer()}</div>
-        );
-      }
-    },
-
-    StaticMethodRemoval: class StaticMethodRemoval extends Component {
-      render() {
-        return (
-          <div>{this.constructor.getAnswer()}</div>
-        );
-      }
+    render() {
+      return (
+        <div>{this.constructor.getAnswer()}</div>
+      );
     }
-  },
-
-  classic: {
-    StaticMethod: React.createClass({
-      statics: {
-        getAnswer() {
-          return 42;
-        }
-      },
-
-      render() {
-        return (
-          <div>{this.constructor.getAnswer()}</div>
-        );
-      }
-    }),
-
-    StaticMethodUpdate: React.createClass({
-      statics: {
-        getAnswer() {
-          return 43;
-        }
-      },
-
-      render() {
-        return (
-          <div>{this.constructor.getAnswer()}</div>
-        );
-      }
-    }),
-
-    StaticMethodRemoval: React.createClass({
-      render() {
-        return (
-          <div>{this.constructor.getAnswer()}</div>
-        );
-      }
-    })
   }
-};
+
+  class StaticMethodUpdate extends Component {
+    static getAnswer() {
+      return 43;
+    };
+
+    render() {
+      return (
+        <div>{this.constructor.getAnswer()}</div>
+      );
+    }
+  }
+
+  class StaticMethodRemoval extends Component {
+    render() {
+      return (
+        <div>{this.constructor.getAnswer()}</div>
+      );
+    }
+  }
+
+  return {
+    StaticMethod,
+    StaticMethodUpdate,
+    StaticMethodRemoval
+  };
+}
+
+function createClassicFixtures() {
+  const StaticMethod = React.createClass({
+    statics: {
+      getAnswer() {
+        return 42;
+      }
+    },
+
+    render() {
+      return (
+        <div>{this.constructor.getAnswer()}</div>
+      );
+    }
+  });
+
+  const StaticMethodUpdate = React.createClass({
+    statics: {
+      getAnswer() {
+        return 43;
+      }
+    },
+
+    render() {
+      return (
+        <div>{this.constructor.getAnswer()}</div>
+      );
+    }
+  });
+
+  const StaticMethodRemoval = React.createClass({
+    render() {
+      return (
+        <div>{this.constructor.getAnswer()}</div>
+      );
+    }
+  });
+
+  return {
+    StaticMethod,
+    StaticMethodUpdate,
+    StaticMethodRemoval
+  };
+}
 
 describe('static method', () => {
   let renderer;
@@ -91,80 +101,94 @@ describe('static method', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const { StaticMethod, StaticMethodUpdate, StaticMethodRemoval } = fixtures[type];
+  function runCommonTests(createFixtures) {
+    let StaticMethod;
+    let StaticMethodUpdate;
+    let StaticMethodRemoval;
+    let CounterWithoutIncrementMethod;
 
-      it('is available on proxy class instance', () => {
-        const proxy = createProxy(StaticMethod);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(Proxy.getAnswer()).toEqual(42);
-      });
-
-      it('is own on proxy class instance', () => {
-        const proxy = createProxy(StaticMethod);
-        const Proxy = proxy.get();
-        expect(Proxy.hasOwnProperty('getAnswer')).toEqual(true);
-      });
-
-      it('gets added', () => {
-        const proxy = createProxy(StaticMethodRemoval);
-        const Proxy = proxy.get();
-        expect(Proxy.getAnswer).toEqual(undefined);
-
-        proxy.update(StaticMethod);
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(Proxy.getAnswer()).toEqual(42);
-      });
-
-      it('gets replaced', () => {
-        const proxy = createProxy(StaticMethod);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(Proxy.getAnswer()).toEqual(42);
-
-        proxy.update(StaticMethodUpdate);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(43);
-        expect(Proxy.getAnswer()).toEqual(43);
-      });
-
-      /**
-       * Known limitation.
-       * If you find a way around it without breaking other tests, let me know!
-       */
-      it('does not get replaced if bound (known limitation)', () => {
-        const proxy = createProxy(StaticMethod);
-        const Proxy = proxy.get();
-        const getAnswer = Proxy.getAnswer = Proxy.getAnswer.bind(Proxy);
-
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-        proxy.update(StaticMethodUpdate);
-        renderer.render(<Proxy />);
-
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(Proxy.getAnswer()).toEqual(42);
-        expect(getAnswer()).toEqual(42);
-      });
-
-      it('is detached if deleted', () => {
-        const proxy = createProxy(StaticMethod);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(Proxy.getAnswer()).toEqual(42);
-
-        proxy.update(StaticMethodRemoval);
-        expect(() => instance.forceUpdate()).toThrow();
-        expect(() => renderer.render(<Proxy />)).toThrow();
-        expect(Proxy.getAnswer).toEqual(undefined);
-      });
+    beforeEach(() => {
+      ({
+        StaticMethod,
+        StaticMethodUpdate,
+        StaticMethodRemoval,
+      } = createFixtures());
     });
+
+    it('is available on proxy class instance', () => {
+      const proxy = createProxy(StaticMethod);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(Proxy.getAnswer()).toEqual(42);
+    });
+
+    it('is own on proxy class instance', () => {
+      const proxy = createProxy(StaticMethod);
+      const Proxy = proxy.get();
+      expect(Proxy.hasOwnProperty('getAnswer')).toEqual(true);
+    });
+
+    it('gets added', () => {
+      const proxy = createProxy(StaticMethodRemoval);
+      const Proxy = proxy.get();
+      expect(Proxy.getAnswer).toEqual(undefined);
+
+      proxy.update(StaticMethod);
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(Proxy.getAnswer()).toEqual(42);
+    });
+
+    it('gets replaced', () => {
+      const proxy = createProxy(StaticMethod);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(Proxy.getAnswer()).toEqual(42);
+
+      proxy.update(StaticMethodUpdate);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(43);
+      expect(Proxy.getAnswer()).toEqual(43);
+    });
+
+    it('gets replaced if bound', () => {
+      const proxy = createProxy(StaticMethod);
+      const Proxy = proxy.get();
+      const getAnswer = Proxy.getAnswer = Proxy.getAnswer.bind(Proxy);
+
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+
+      proxy.update(StaticMethodUpdate);
+      renderer.render(<Proxy />);
+
+      expect(renderer.getRenderOutput().props.children).toEqual(43);
+      expect(Proxy.getAnswer()).toEqual(43);
+      // Can we make this work too? Probably isn't worth bothering:
+      expect(getAnswer()).toEqual(42);
+    });
+
+    it('is detached if deleted', () => {
+      const proxy = createProxy(StaticMethod);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual(42);
+      expect(Proxy.getAnswer()).toEqual(42);
+
+      proxy.update(StaticMethodRemoval);
+      expect(() => instance.forceUpdate()).toThrow();
+      expect(() => renderer.render(<Proxy />)).toThrow();
+      expect(Proxy.getAnswer).toEqual(undefined);
+    });
+  }
+
+  describe('classic', () => {
+    runCommonTests(createClassicFixtures);
+  });
+
+  describe('modern', () => {
+    runCommonTests(createModernFixtures);
   });
 });

--- a/test/static-property.js
+++ b/test/static-property.js
@@ -3,131 +3,163 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    StaticProperty: class StaticProperty extends Component {
-      static answer = 42;
+function createModernFixtures() {
+  class StaticProperty extends Component {
+    static answer = 42;
 
-      render() {
-        return (
-          <div>{this.constructor.answer}</div>
-        );
-      }
-    },
-
-    StaticPropertyUpdate: class StaticPropertyUpdate extends Component {
-      static answer = 43;
-
-      render() {
-        return (
-          <div>{this.constructor.answer}</div>
-        );
-      }
-    },
-
-    StaticPropertyRemoval: class StaticPropertyRemoval extends Component {
-      render() {
-        return (
-          <div>{this.constructor.answer}</div>
-        );
-      }
-    },
-
-    PropTypes: class PropTypes extends Component {
-      static propTypes = {
-        something: React.PropTypes.number
-      };
-
-      static contextTypes = {
-        something: React.PropTypes.number
-      };
-
-      static childContextTypes = {
-        something: React.PropTypes.number
-      };
-    },
-
-    PropTypesUpdate: class PropTypesUpdate extends Component {
-      static propTypes = {
-        something: React.PropTypes.string
-      };
-
-      static contextTypes = {
-        something: React.PropTypes.string
-      };
-
-      static childContextTypes = {
-        something: React.PropTypes.string
-      };
+    render() {
+      return (
+        <div>
+          {StaticProperty.answer}
+          {this.constructor.answer}
+        </div>
+      );
     }
-  },
-
-  classic: {
-    StaticProperty: React.createClass({
-      statics: {
-        answer: 42
-      },
-
-      render() {
-        return (
-          <div>{this.constructor.answer}</div>
-        );
-      }
-    }),
-
-    StaticPropertyUpdate: React.createClass({
-      statics: {
-        answer: 43
-      },
-
-      render() {
-        return (
-          <div>{this.constructor.answer}</div>
-        );
-      }
-    }),
-
-    StaticPropertyRemoval: React.createClass({
-      render() {
-        return (
-          <div>{this.constructor.answer}</div>
-        );
-      }
-    }),
-
-    PropTypes: React.createClass({
-      render() {},
-
-      propTypes: {
-        something: React.PropTypes.number
-      },
-
-      contextTypes: {
-        something: React.PropTypes.number
-      },
-
-      childContextTypes: {
-        something: React.PropTypes.number
-      }
-    }),
-
-    PropTypesUpdate: React.createClass({
-      render() {},
-
-      propTypes: {
-        something: React.PropTypes.string
-      },
-
-      contextTypes: {
-        something: React.PropTypes.string
-      },
-
-      childContextTypes: {
-        something: React.PropTypes.string
-      }
-    })
   }
-};
+
+  class StaticPropertyUpdate extends Component {
+    static answer = 43;
+
+    render() {
+      return (
+        <div>
+          {StaticPropertyUpdate.answer}
+          {this.constructor.answer}
+        </div>
+      );
+    }
+  }
+
+  class StaticPropertyRemoval extends Component {
+    render() {
+      return (
+        <div>
+          {StaticPropertyRemoval.answer}
+          {this.constructor.answer}
+        </div>
+      );
+    }
+  }
+
+  class PropTypes extends Component {
+    static propTypes = {
+      something: React.PropTypes.number
+    };
+
+    static contextTypes = {
+      something: React.PropTypes.number
+    };
+
+    static childContextTypes = {
+      something: React.PropTypes.number
+    };
+  }
+
+  class PropTypesUpdate extends Component {
+    static propTypes = {
+      something: React.PropTypes.string
+    };
+
+    static contextTypes = {
+      something: React.PropTypes.string
+    };
+
+    static childContextTypes = {
+      something: React.PropTypes.string
+    };
+  }
+
+  return {
+    StaticProperty,
+    StaticPropertyUpdate,
+    StaticPropertyRemoval,
+    PropTypes,
+    PropTypesUpdate
+  };
+}
+
+function createClassicFixtures() {
+  const StaticProperty = React.createClass({
+    statics: {
+      answer: 42
+    },
+
+    render() {
+      return (
+        <div>
+          {StaticProperty.answer}
+          {this.constructor.answer}
+        </div>
+      );
+    }
+  });
+
+  const StaticPropertyUpdate = React.createClass({
+    statics: {
+      answer: 43
+    },
+
+    render() {
+      return (
+        <div>
+          {StaticPropertyUpdate.answer}
+          {this.constructor.answer}
+        </div>
+      );
+    }
+  });
+
+  const StaticPropertyRemoval = React.createClass({
+    render() {
+      return (
+        <div>
+          {StaticPropertyRemoval.answer}
+          {this.constructor.answer}
+        </div>
+      );
+    }
+  });
+
+  const PropTypes = React.createClass({
+    render() {},
+
+    propTypes: {
+      something: React.PropTypes.number
+    },
+
+    contextTypes: {
+      something: React.PropTypes.number
+    },
+
+    childContextTypes: {
+      something: React.PropTypes.number
+    }
+  });
+
+  const PropTypesUpdate = React.createClass({
+    render() {},
+
+    propTypes: {
+      something: React.PropTypes.string
+    },
+
+    contextTypes: {
+      something: React.PropTypes.string
+    },
+
+    childContextTypes: {
+      something: React.PropTypes.string
+    }
+  });
+
+  return {
+    StaticProperty,
+    StaticPropertyUpdate,
+    StaticPropertyRemoval,
+    PropTypes,
+    PropTypesUpdate
+  };
+}
 
 describe('static property', () => {
   let renderer;
@@ -143,78 +175,128 @@ describe('static property', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const {
-        StaticProperty, StaticPropertyUpdate, StaticPropertyRemoval,
-        PropTypes, PropTypesUpdate
-      } = fixtures[type];
+  function runCommonTests(createFixtures) {
+    let StaticProperty;
+    let StaticPropertyUpdate;
+    let StaticPropertyRemoval;
+    let PropTypes;
+    let PropTypesUpdate;
 
-      it('is available on proxy class instance', () => {
-        const proxy = createProxy(StaticProperty);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-        expect(Proxy.answer).toEqual(42);
-      });
-
-      it('is own on proxy class instance', () => {
-        const proxy = createProxy(StaticProperty);
-        const Proxy = proxy.get();
-        expect(Proxy.hasOwnProperty('answer')).toEqual(true);
-      });
-
-      it('is changed when not reassigned', () => {
-        const proxy = createProxy(StaticProperty);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-        proxy.update(StaticPropertyUpdate);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(43);
-        expect(Proxy.answer).toEqual(43);
-
-        proxy.update(StaticPropertyRemoval);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(undefined);
-        expect(Proxy.answer).toEqual(undefined);
-      });
-
-      it('is changed for propTypes, contextTypes, childContextTypes', () => {
-        const proxy = createProxy(PropTypes);
-        const PropTypesProxy = proxy.get();
-        expect(PropTypesProxy.propTypes.something).toEqual(React.PropTypes.number);
-        expect(PropTypesProxy.contextTypes.something).toEqual(React.PropTypes.number);
-        expect(PropTypesProxy.childContextTypes.something).toEqual(React.PropTypes.number);
-
-        proxy.update(PropTypesUpdate);
-        expect(PropTypesProxy.propTypes.something).toEqual(React.PropTypes.string);
-        expect(PropTypesProxy.contextTypes.something).toEqual(React.PropTypes.string);
-        expect(PropTypesProxy.childContextTypes.something).toEqual(React.PropTypes.string);
-      });
-
-      /**
-       * Sometimes people dynamically store stuff on statics.
-       */
-      it('is not changed when reassigned', () => {
-        const proxy = createProxy(StaticProperty);
-        const Proxy = proxy.get();
-        const instance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(42);
-
-        Proxy.answer = 100;
-
-        proxy.update(StaticPropertyUpdate);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(100);
-        expect(Proxy.answer).toEqual(100);
-
-        proxy.update(StaticPropertyRemoval);
-        renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual(100);
-        expect(Proxy.answer).toEqual(100);
-      });
+    beforeEach(() => {
+      ({
+        StaticProperty,
+        StaticPropertyUpdate,
+        StaticPropertyRemoval,
+        PropTypes,
+        PropTypesUpdate
+      } = createFixtures());
     });
+
+    it('is available on both classes', () => {
+      const proxy = createProxy(StaticProperty);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([42, 42]);
+      expect(StaticProperty.answer).toEqual(42);
+      expect(Proxy.answer).toEqual(42);
+    });
+
+    it('is own on both classes', () => {
+      const proxy = createProxy(StaticProperty);
+      const Proxy = proxy.get();
+      expect(StaticProperty.hasOwnProperty('answer')).toEqual(true);
+      expect(Proxy.hasOwnProperty('answer')).toEqual(true);
+    });
+
+    it('is changed when not reassigned', () => {
+      const proxy = createProxy(StaticProperty);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([42, 42]);
+      expect(StaticProperty.answer).toEqual(42);
+      expect(Proxy.answer).toEqual(42);
+
+      proxy.update(StaticPropertyUpdate);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([43, 43]);
+      expect(StaticPropertyUpdate.answer).toEqual(43);
+      expect(Proxy.answer).toEqual(43);
+
+      proxy.update(StaticPropertyRemoval);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([undefined, undefined]);
+      expect(StaticPropertyRemoval.answer).toEqual(undefined);
+      expect(Proxy.answer).toEqual(undefined);
+    });
+
+    it('is changed for propTypes, contextTypes, childContextTypes', () => {
+      const proxy = createProxy(PropTypes);
+      const PropTypesProxy = proxy.get();
+      expect(PropTypesProxy.propTypes.something).toEqual(React.PropTypes.number);
+      expect(PropTypesProxy.contextTypes.something).toEqual(React.PropTypes.number);
+      expect(PropTypesProxy.childContextTypes.something).toEqual(React.PropTypes.number);
+
+      proxy.update(PropTypesUpdate);
+      expect(PropTypesProxy.propTypes.something).toEqual(React.PropTypes.string);
+      expect(PropTypesProxy.contextTypes.something).toEqual(React.PropTypes.string);
+      expect(PropTypesProxy.childContextTypes.something).toEqual(React.PropTypes.string);
+    });
+
+    it('is not changed when reassigned on initial class (declared)', () => {
+      const proxy = createProxy(StaticProperty);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([42, 42]);
+
+      StaticProperty.answer = 100;
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([100, 100]);
+      expect(StaticProperty.answer).toEqual(100);
+      expect(Proxy.answer).toEqual(42); // Proxy gets synced on update()
+
+      proxy.update(StaticPropertyUpdate);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([100, 100]);
+      expect(StaticPropertyUpdate.answer).toEqual(100);
+      expect(Proxy.answer).toEqual(100);
+
+      proxy.update(StaticPropertyRemoval);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([100, 100]);
+      expect(StaticPropertyRemoval.answer).toEqual(100);
+      expect(Proxy.answer).toEqual(100);
+    });
+
+    it('is not changed when reassigned on initial class (undeclared)', () => {
+      const proxy = createProxy(StaticPropertyRemoval);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([undefined, undefined]);
+
+      StaticPropertyRemoval.answer = 100;
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([100, 100]);
+      expect(Proxy.answer).toEqual(undefined); // Proxy gets synced on update()
+
+      proxy.update(StaticPropertyUpdate);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([100, 100]);
+      expect(StaticPropertyUpdate.answer).toEqual(100);
+      expect(Proxy.answer).toEqual(100);
+
+      proxy.update(StaticProperty);
+      renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual([100, 100]);
+      expect(StaticPropertyRemoval.answer).toEqual(100);
+      expect(Proxy.answer).toEqual(100);
+    });
+  }
+
+  describe('classic', () => {
+    runCommonTests(createClassicFixtures);
+  });
+
+  describe('modern', () => {
+    runCommonTests(createModernFixtures);
   });
 });

--- a/test/unmounting.js
+++ b/test/unmounting.js
@@ -3,71 +3,81 @@ import createShallowRenderer from './helpers/createShallowRenderer';
 import expect from 'expect';
 import createProxy from '../src';
 
-const fixtures = {
-  modern: {
-    Bar: class Bar extends Component {
-      componentWillUnmount() {
-        this.didUnmount = true;
-      }
-
-      render() {
-        return <div>Bar</div>;
-      }
-    },
-
-    Baz: class Baz extends Component {
-      componentWillUnmount() {
-        this.didUnmount = true;
-      }
-
-      render() {
-        return <div>Baz</div>;
-      }
-    },
-
-    Foo: class Foo extends Component {
-      componentWillUnmount() {
-        this.didUnmount = true;
-      }
-
-      render() {
-        return <div>Foo</div>;
-      }
+function createModernFixtures() {
+  class Bar extends Component {
+    componentWillUnmount() {
+      this.didUnmount = true;
     }
-  },
 
-  classic: {
-    Bar: React.createClass({
-      componentWillUnmount() {
-        this.didUnmount = true;
-      },
-
-      render() {
-        return <div>Bar</div>;
-      }
-    }),
-
-    Baz: React.createClass({
-      componentWillUnmount() {
-        this.didUnmount = true;
-      },
-
-      render() {
-        return <div>Baz</div>;
-      }
-    }),
-
-    Foo: React.createClass({
-      componentWillUnmount() {
-        this.didUnmount = true;
-      },
-
-      render() {
-        return <div>Foo</div>;
-      }
-    })
+    render() {
+      return <div>Bar</div>;
+    }
   }
-};
+
+  class Baz extends Component {
+    componentWillUnmount() {
+      this.didUnmount = true;
+    }
+
+    render() {
+      return <div>Baz</div>;
+    }
+  }
+
+  class Foo extends Component {
+    componentWillUnmount() {
+      this.didUnmount = true;
+    }
+
+    render() {
+      return <div>Foo</div>;
+    }
+  }
+
+  return {
+    Bar,
+    Baz,
+    Foo
+  };
+}
+
+function createClassicFixtures() {
+  const Bar = React.createClass({
+    componentWillUnmount() {
+      this.didUnmount = true;
+    },
+
+    render() {
+      return <div>Bar</div>;
+    }
+  });
+
+  const Baz = React.createClass({
+    componentWillUnmount() {
+      this.didUnmount = true;
+    },
+
+    render() {
+      return <div>Baz</div>;
+    }
+  });
+
+  const Foo = React.createClass({
+    componentWillUnmount() {
+      this.didUnmount = true;
+    },
+
+    render() {
+      return <div>Foo</div>;
+    }
+  });
+
+  return {
+    Bar,
+    Baz,
+    Foo
+  };
+}
 
 describe('unmounting', () => {
   let renderer;
@@ -83,58 +93,74 @@ describe('unmounting', () => {
     expect(warnSpy.calls.length).toBe(0);
   });
 
-  Object.keys(fixtures).forEach(type => {
-    describe(type, () => {
-      const { Bar, Baz, Foo } = fixtures[type];
+  function runCommonTests(createFixtures) {
+    let Bar;
+    let Baz;
+    let Foo;
 
-      it('happens without proxy', () => {
-        const barInstance = renderer.render(<Bar />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Bar');
-        const bazInstance = renderer.render(<Baz />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Baz');
-        expect(barInstance).toNotEqual(bazInstance);
-        expect(barInstance.didUnmount).toEqual(true);
-      });
-
-      it('does not happen when rendering new proxied versions', () => {
-        const proxy = createProxy(Bar);
-        const BarProxy = proxy.get();
-        const barInstance = renderer.render(<BarProxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Bar');
-
-        proxy.update(Baz);
-        const BazProxy = proxy.get();
-        const bazInstance = renderer.render(<BazProxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Baz');
-        expect(barInstance).toEqual(bazInstance);
-        expect(barInstance.didUnmount).toEqual(undefined);
-
-        proxy.update(Foo);
-        const FooProxy = proxy.get();
-        const fooInstance = renderer.render(<FooProxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Foo');
-        expect(barInstance).toEqual(fooInstance);
-        expect(barInstance.didUnmount).toEqual(undefined);
-      });
-
-      it('does not happen when rendering old proxied versions', () => {
-        const proxy = createProxy(Bar);
-        const Proxy = proxy.get();
-        const barInstance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Bar');
-
-        proxy.update(Baz);
-        const bazInstance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Baz');
-        expect(barInstance).toEqual(bazInstance);
-        expect(barInstance.didUnmount).toEqual(undefined);
-
-        proxy.update(Foo);
-        const fooInstance = renderer.render(<Proxy />);
-        expect(renderer.getRenderOutput().props.children).toEqual('Foo');
-        expect(barInstance).toEqual(fooInstance);
-        expect(barInstance.didUnmount).toEqual(undefined);
-      });
+    beforeEach(() => {
+      ({
+        Bar,
+        Baz,
+        Foo
+      } = createFixtures());
     });
+
+    it('happens without proxy', () => {
+      const barInstance = renderer.render(<Bar />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Bar');
+      const bazInstance = renderer.render(<Baz />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Baz');
+      expect(barInstance).toNotEqual(bazInstance);
+      expect(barInstance.didUnmount).toEqual(true);
+    });
+
+    it('does not happen when rendering new proxied versions', () => {
+      const proxy = createProxy(Bar);
+      const BarProxy = proxy.get();
+      const barInstance = renderer.render(<BarProxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Bar');
+
+      proxy.update(Baz);
+      const BazProxy = proxy.get();
+      const bazInstance = renderer.render(<BazProxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Baz');
+      expect(barInstance).toEqual(bazInstance);
+      expect(barInstance.didUnmount).toEqual(undefined);
+
+      proxy.update(Foo);
+      const FooProxy = proxy.get();
+      const fooInstance = renderer.render(<FooProxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Foo');
+      expect(barInstance).toEqual(fooInstance);
+      expect(barInstance.didUnmount).toEqual(undefined);
+    });
+
+    it('does not happen when rendering old proxied versions', () => {
+      const proxy = createProxy(Bar);
+      const Proxy = proxy.get();
+      const barInstance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Bar');
+
+      proxy.update(Baz);
+      const bazInstance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Baz');
+      expect(barInstance).toEqual(bazInstance);
+      expect(barInstance.didUnmount).toEqual(undefined);
+
+      proxy.update(Foo);
+      const fooInstance = renderer.render(<Proxy />);
+      expect(renderer.getRenderOutput().props.children).toEqual('Foo');
+      expect(barInstance).toEqual(fooInstance);
+      expect(barInstance.didUnmount).toEqual(undefined);
+    });
+  }
+
+  describe('classic', () => {
+    runCommonTests(createClassicFixtures);
+  });
+
+  describe('modern', () => {
+    runCommonTests(createModernFixtures);
   });
 });


### PR DESCRIPTION
Changes related to the “wrap during `createElement`” approach described [here](https://medium.com/@dan_abramov/hot-reloading-in-react-1140438583bf):
- The current class is now `this.constructor`, not the proxy class
- The passed classes are mutated, e.g. when you `update()`, static properties created dynamically on the previous class get copied to the next class
- Tests are now properly isolated because of this

Example of this in action: https://github.com/gaearon/react-hot-boilerplate/pull/61
