### PR TITLE
Avoid using displayName as function name since it does not have to be a valid identifier.

### DIFF
--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -77,9 +77,9 @@ function proxyClass(InitialComponent) {
 
   let displayName = getDisplayName(InitialComponent);
   try {
-    // Create a proxy constructor with matching name
+    // Create a proxy constructor with a generic name
     ProxyComponent = new Function('factory', 'instantiate',
-      `return function ${displayName}() {
+      `return function DynamicProxyComponent() {
          return instantiate(factory, this, arguments);
       }`
     )(() => CurrentComponent, instantiate);


### PR DESCRIPTION
A very simple solution to the issue discussed in this pull request https://github.com/gaearon/react-proxy/pull/58