### PR TITLE
Allow supplying an error catcher component

### DIFF
--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -47,7 +47,7 @@ function addProxy(Component, proxy) {
   allProxies.push([Component, proxy]);
 }
 
-function proxyClass(InitialComponent) {
+function proxyClass(InitialComponent, ErrorComponent) {
   // Prevent double wrapping.
   // Given a proxy class, return the existing proxy managing it.
   var existingProxy = findProxy(InitialComponent);
@@ -103,7 +103,7 @@ function proxyClass(InitialComponent) {
   let prototypeProxy;
   if (InitialComponent.prototype && InitialComponent.prototype.isReactComponent) {
     // Point proxy constructor to the proxy prototype
-    prototypeProxy = createPrototypeProxy();
+    prototypeProxy = createPrototypeProxy(ErrorComponent);
     ProxyComponent.prototype = prototypeProxy.get();
   }
 
@@ -257,8 +257,8 @@ function createFallback(Component) {
   };
 }
 
-export default function createClassProxy(Component) {
+export default function createClassProxy(Component, ErrorComponent) {
   return Component.__proto__ && supportsProtoAssignment() ?
-    proxyClass(Component) :
+    proxyClass(Component, ErrorComponent) :
     createFallback(Component);
 }


### PR DESCRIPTION
This is the first cut for error catching facilities in `react-proxy`.

This works on classic and class components, without breaking any existing tests.

Because the error component is optional, most of the tested code paths don't actually touch the new code. I wasn't sure how many tests to expand to cover this, so I figured I'd show what I have so far.

As this is a nice incremental change, I think it's useful to aim to merge this without pure component support initially - that might require more invasion changes.

For pure components, I *think* that https://github.com/gaearon/react-proxy/blob/c019762362a4936ed86d6bb89ad6a57e13de6c06/src/createClassProxy.js#L65-67 might have to change to use detection (like with https://github.com/gaearon/react-proxy/blob/c019762362a4936ed86d6bb89ad6a57e13de6c06/src/createClassProxy.js#L104) instead of a fallback.

One thing I did wonder about just now - what happens if you attempt to replace a component defined with one approach, with a component defined using a different approach?