### PR TITLE
Catch Throws from Non-Configurable Properties

### DIFF
--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -148,7 +148,9 @@ function proxyClass(InitialComponent) {
         const savedDescriptor = savedDescriptors[key];
 
         if (!isEqualDescriptor(prevDescriptor, savedDescriptor)) {
-          Object.defineProperty(NextComponent, key, prevDescriptor);
+          try {
+            Object.defineProperty(NextComponent, key, prevDescriptor);
+          } catch (err) { }
         }
       });
     }
@@ -164,8 +166,10 @@ function proxyClass(InitialComponent) {
 
       // Skip redefined descriptors
       if (prevDescriptor && savedDescriptor && !isEqualDescriptor(savedDescriptor, prevDescriptor)) {
-        Object.defineProperty(NextComponent, key, prevDescriptor);
-        Object.defineProperty(ProxyComponent, key, prevDescriptor);
+        try {
+          Object.defineProperty(NextComponent, key, prevDescriptor);
+          Object.defineProperty(ProxyComponent, key, prevDescriptor);
+        } catch (err) { }
         return;
       }
 

--- a/test/static-descriptor.js
+++ b/test/static-descriptor.js
@@ -92,6 +92,24 @@ describe('static descriptor', () => {
       expect(() => proxy.update(ThrowingAccessors)).toNotThrow();
     });
 
+    it('replaces non-configurable properties', () => {
+      Object.defineProperty(StaticDescriptor, 'nonConfigProp', {
+        configurable: false,
+        value: 10,
+      });
+      Object.defineProperty(StaticDescriptorUpdate, 'nonConfigProp', {
+        configurable: false,
+        value: 11,
+      });
+
+      const proxy = createProxy(StaticDescriptor);
+      const Proxy = proxy.get();
+      const instance = renderer.render(<Proxy />);
+      expect(instance.constructor.nonConfigProp).toEqual(10);
+      proxy.update(StaticDescriptorUpdate);
+      expect(instance.constructor.nonConfigProp).toEqual(11);
+    });
+
     describe('getter', () => {
       it('is available on proxy class', () => {
         const proxy = createProxy(StaticDescriptor);


### PR DESCRIPTION
This is in response to issues #61 where when defining properties with configurable set to false, the proxying process would throw the error: `TypeError: Cannot redefine property`. This fix adds a try catch around the places where properties are redefined and a test to verify that the proxy method contains the newly defined value. I am assuming the code should use the defined value on the updated Component (ie Component1 has non-configurable property 10 then update to Component2 which has non-configurable property 11 so the value should be 11).

Closes #61 
