### PR TITLE
Proxy fixes

### DIFF
--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -54,7 +54,7 @@ function proxyClass(Component) {
   if (existingProxy) {
     return existingProxy;
   }
-
+  let OriginalComponent = Component
   let newComponent = null
   let newComponentInstance = null
   let proxyInstance = null
@@ -137,10 +137,14 @@ function proxyClass(Component) {
       }
 
       newComponent = NewComponent
+      OriginalComponent = newComponent
+
       if (newComponent.prototype.isReactComponent) {
         // Set initial state for newly mounted component
         if (proxyInstance) {
 
+          Object.setPrototypeOf(proxyInstance, newComponent.prototype)
+  
           // Get props from proxy to prevent undefined variables in render()
           const { context, props, state } = proxyInstance
 

--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -75,8 +75,9 @@ function proxyClass(Component) {
             'context',
             'constructor',
             'selector',
-            'props'
-          ]
+            'props',
+            'didUnmount'
+          ] // Can we get those automatically?
 
           const reactLifecycleMethods = [
             'shouldComponentUpdate',
@@ -85,11 +86,9 @@ function proxyClass(Component) {
           ]
 
           if (newComponentInstance) {
-
-            if (!reactInternals.includes(propKey)) {
-
-              if (!reactLifecycleMethods.includes(propKey)) {
-
+            if (reactInternals.includes(propKey) || reactLifecycleMethods.includes(propKey)) {
+              return Reflect.get(target, propKey, receiver);
+            }
                 const originalComponentWillUpdate = newComponentInstance.componentWillUpdate
                 newComponentInstance.componentWillUpdate = function(nextProps, nextState) {
                   proxyInstance.setState(nextState)
@@ -100,14 +99,6 @@ function proxyClass(Component) {
 
                 return Reflect.get(newComponentInstance, propKey, receiver);
               }
-
-              return Reflect.get(target, propKey, receiver);
-            } else {
-              return Reflect.get(target, propKey, receiver);
-            }
-
-          }
-
           return Reflect.get(target, propKey, receiver);
         }
       })

--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -1,7 +1,4 @@
 import find from 'lodash/find';
-import createPrototypeProxy from './createPrototypeProxy';
-import bindAutoBindMethods from './bindAutoBindMethods';
-import deleteUnknownAutoBindMethods from './deleteUnknownAutoBindMethods';
 import supportsProtoAssignment from './supportsProtoAssignment';
 import React from 'react';
 import { shallow } from 'enzyme';

--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -39,7 +39,7 @@ function getDisplayName(Component) {
 // https://github.com/gaearon/react-proxy/issues/50#issuecomment-192928066
 let allProxies = [];
 function findProxy(Component) {
-  const pair = find(allProxies, ([key]) => key === Component);
+  const pair = find(allProxies, ([key, wrapper]) => key === Component || Component === wrapper.get());
   return pair ? pair[1] : null;
 }
 function addProxy(Component, proxy) {

--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -115,7 +115,14 @@ function proxyClass(Component) {
         return Reflect.get(newComponent, propKey, receiver);
       }
       return Reflect.get(target, propKey, receiver);
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (newComponent) {
+        return Reflect.getOwnPropertyDescriptor(newComponent, prop);
     }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    }
+
   });
 
   const proxy = {


### PR DESCRIPTION
@wkwiatek this is the actual change in `createClassProxy`
- Improve cached Proxies lookup
- Add trap for `getOwnPropertyDescriptor` method of an instance
- Inject updated component into prototype chain