### PR TITLE
Remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "webpack": "1.4.8"
   },
   "dependencies": {
-    "lodash": "^4.6.1",
     "react-deep-force-update": "^1.0.0"
   }
 }

--- a/src/createClassProxy.js
+++ b/src/createClassProxy.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find';
 import createPrototypeProxy from './createPrototypeProxy';
 import bindAutoBindMethods from './bindAutoBindMethods';
 import deleteUnknownAutoBindMethods from './deleteUnknownAutoBindMethods';
@@ -32,14 +31,14 @@ function isEqualDescriptor(a, b) {
 // https://github.com/gaearon/react-proxy/issues/50#issuecomment-192928066
 let allProxies = [];
 function findProxy(Component) {
-  const pair = find(allProxies, ([key]) => key === Component);
+  const pair = allProxies.find(([key]) => key === Component);
   return pair ? pair[1] : null;
 }
 function addProxy(Component, proxy) {
   allProxies.push([Component, proxy]);
 }
 
-export default function proxyClass(InitialComponent) {
+export function proxyClass(InitialComponent) {
   // Prevent double wrapping.
   // Given a proxy class, return the existing proxy managing it.
   var existingProxy = findProxy(InitialComponent);

--- a/src/createPrototypeProxy.js
+++ b/src/createPrototypeProxy.js
@@ -1,6 +1,3 @@
-import assign from 'lodash/assign';
-import difference from 'lodash/difference';
-
 export default function createPrototypeProxy() {
   let proxy = {};
   let current = null;
@@ -32,7 +29,7 @@ export default function createPrototypeProxy() {
     };
 
     // Copy properties of the original function, if any
-    assign(proxiedMethod, current[name]);
+    Object.assign(proxiedMethod, current[name]);
     proxiedMethod.toString = proxyToString(name);
 
     return proxiedMethod;
@@ -132,9 +129,11 @@ export default function createPrototypeProxy() {
     current = next;
 
     // Find changed property names
-    const currentNames = Object.getOwnPropertyNames(current);
+    const currentNames = new Set(Object.getOwnPropertyNames(current));
     const previousName = Object.getOwnPropertyNames(proxy);
-    const removedNames = difference(previousName, currentNames);
+    const removedNames = previousName.filter(
+      property => !currentNames.has(property),
+    );
 
     // Remove properties and methods that are no longer there
     removedNames.forEach(name => {

--- a/src/createPrototypeProxy.js
+++ b/src/createPrototypeProxy.js
@@ -129,10 +129,21 @@ export default function createPrototypeProxy() {
     current = next;
 
     // Find changed property names
-    const currentNames = new Set(Object.getOwnPropertyNames(current));
+    const currentNames = Object.getOwnPropertyNames(current);
     const previousName = Object.getOwnPropertyNames(proxy);
+
+    // Map the property names as keys in an object to get constant time access
+    // when calculating the removed properties.
+    const currentNamesObject = currentNames.reduce(
+      (acc, property) => {
+        acc[property] = true;
+        return acc;
+      },
+      Object.create(null),
+    );
+
     const removedNames = previousName.filter(
-      property => !currentNames.has(property),
+      property => !currentNames[property],
     );
 
     // Remove properties and methods that are no longer there


### PR DESCRIPTION
Since all the `lodash` functionality used in this module can be currently
implemented easily using ES6, there is no need to include it.

When using `metro-bundler` with Hot Module Reloading in React Native, this change reduces the bundle size by ~77KB and makes `metro-bundler` build around ~150 less modules.