### PR TITLE
shouldDeleteModernInstanceMethod shouldn’t call get()

### DIFF
--- a/src/deleteUnknownAutoBindMethods.js
+++ b/src/deleteUnknownAutoBindMethods.js
@@ -28,7 +28,7 @@ function shouldDeleteModernInstanceMethod(component, name) {
     return false;
   }
 
-  if (prototypeDescriptor.get().length !== component[name].length) {
+  if (prototypeDescriptor.get.length !== component[name].length) {
     // The length doesn't match, bail out
     return false;
   }


### PR DESCRIPTION
hi,

this does fix #71

thanks to @finneganh
